### PR TITLE
Update .rubocop_todo.yml

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Lint/UnneededCopEnableDirective:
+Lint/RedundantCopEnableDirective:
   Exclude:
     - 'graphql-types-money.gemspec'
 


### PR DESCRIPTION
Error: The `Lint/UnneededCopEnableDirective` cop has been renamed to `Lint/RedundantCopEnableDirective`.
rubocop 1.20, has been giving me headaches on circleci